### PR TITLE
removed unused import that causes build failure

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/androidsigning/SignArtifactPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/androidsigning/SignArtifactPlugin.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.androidsigning;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.sun.jdi.connect.Connector;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;


### PR DESCRIPTION
not sure why the import of the internal java class was included, but it caused a build error with openjdk on linux and didn't seem to be used anywhere in this class anyways